### PR TITLE
another attempt at ignoring run-exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,8 @@ source:
     - patches/0006-Make-RTLD_LOCAL-work-correctly-for-preloaded-DSOs-21.patch
 
 build:
-  number: 1
-  ignore_run_exports_from:
+  number: 2
+  ignore_run_exports:
     # needs indirection, otherwise smithy thinks "multiple python"
     - {{ nameless_python }}
     # same for nodejs


### PR DESCRIPTION
Neither #27 nor actually ended up ignoring the run-exports from python/nodejs